### PR TITLE
Update bn

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         platform: [x86, x64, ARM64]
-        config: [Debug, Release]
+        config: [Release]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2.3.3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,8 +100,10 @@ jobs:
     strategy:
       matrix:
         platform: [x86, x64, ARM64]
-        config: [Release]
+        config: [Debug, Release]
     steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
       - name: Checkout Repo
         uses: actions/checkout@v2.3.3
         with:

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -186,6 +186,7 @@
         etc2.lib;
         GenericCodeGend.lib;
         glslangd.lib;
+		glslang-default-resource-limitsd.lib
         Graphics.lib;
         iqa.lib;
         jsi.lib;
@@ -247,6 +248,7 @@
         etc2.lib;
         GenericCodeGen.lib;
         glslang.lib;
+		glslang-default-resource-limits.lib
         Graphics.lib;
         iqa.lib;
         jsi.lib;

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -129,15 +129,12 @@
       <AdditionalLibraryDirectories Condition="'$(BabylonNativeBuildDir)' != ''">
         $(BabylonNativeBuildDir)BabylonNative\Core\JsRuntime\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Core\Graphics\$(Configuration);
-        $(BabylonNativeBuildDir)BabylonNative\Dependencies\arcana.cpp\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\bgfx.cmake\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\glslang\glslang\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\glslang\glslang\OSDependent\Windows\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\glslang\OGLCompilersDLL\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\glslang\SPIRV\$(Configuration);
-        $(BabylonNativeBuildDir)BabylonNative\Dependencies\napi\napi-jsi\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\SPIRV-Cross\$(Configuration);
-        $(BabylonNativeBuildDir)BabylonNative\Dependencies\UrlLib\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\xr\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Dependencies\xr\Dependencies\OpenXR-SDK\src\loader\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Plugins\NativeCamera\$(Configuration);
@@ -148,10 +145,14 @@
         $(BabylonNativeBuildDir)BabylonNative\Plugins\NativeTracing\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Plugins\NativeXr\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Polyfills\Window\$(Configuration);
-        $(BabylonNativeBuildDir)BabylonNative\Polyfills\XMLHttpRequest\$(Configuration);
         $(BabylonNativeBuildDir)BabylonNative\Polyfills\Canvas\$(Configuration);
         $(BabylonNativeBuildDir)jsi\$(Configuration);
         $(BabylonNativeBuildDir)$(Configuration);
+		$(BabylonNativeBuildDir)_deps\arcana-build\$(Configuration);
+		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\JsRuntime\$(Configuration);
+		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\Node-API-JSI\$(Configuration);
+		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Polyfills\XMLHttpRequest\$(Configuration);
+		$(BabylonNativeBuildDir)_deps\urllib-build\$(Configuration);
         %(AdditionalLibraryDirectories);
       </AdditionalLibraryDirectories>
       <!-- Library directories when building from npm package -->

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -148,11 +148,11 @@
         $(BabylonNativeBuildDir)BabylonNative\Polyfills\Canvas\$(Configuration);
         $(BabylonNativeBuildDir)jsi\$(Configuration);
         $(BabylonNativeBuildDir)$(Configuration);
-		$(BabylonNativeBuildDir)_deps\arcana-build\$(Configuration);
-		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\JsRuntime\$(Configuration);
-		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\Node-API-JSI\$(Configuration);
-		$(BabylonNativeBuildDir)_deps\jsruntimehost-build\Polyfills\XMLHttpRequest\$(Configuration);
-		$(BabylonNativeBuildDir)_deps\urllib-build\$(Configuration);
+        $(BabylonNativeBuildDir)_deps\arcana-build\$(Configuration);
+        $(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\JsRuntime\$(Configuration);
+        $(BabylonNativeBuildDir)_deps\jsruntimehost-build\Core\Node-API-JSI\$(Configuration);
+        $(BabylonNativeBuildDir)_deps\jsruntimehost-build\Polyfills\XMLHttpRequest\$(Configuration);
+        $(BabylonNativeBuildDir)_deps\urllib-build\$(Configuration);
         %(AdditionalLibraryDirectories);
       </AdditionalLibraryDirectories>
       <!-- Library directories when building from npm package -->
@@ -186,7 +186,7 @@
         etc2.lib;
         GenericCodeGend.lib;
         glslangd.lib;
-		glslang-default-resource-limitsd.lib
+        glslang-default-resource-limitsd.lib;
         Graphics.lib;
         iqa.lib;
         jsi.lib;
@@ -248,7 +248,7 @@
         etc2.lib;
         GenericCodeGen.lib;
         glslang.lib;
-		glslang-default-resource-limits.lib
+        glslang-default-resource-limits.lib;
         Graphics.lib;
         iqa.lib;
         jsi.lib;

--- a/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
@@ -22,6 +22,8 @@ set(BABYLON_NATIVE_BUILD_APPS OFF CACHE BOOL "")
 set(BABYLON_NATIVE_USE_SWAPCHAINPANEL ON CACHE BOOL "")
 set(BABYLON_NATIVE_DIR "${BABYLON_REACT_NATIVE_IOSANDROID}/submodules/BabylonNative")
 add_subdirectory(${BABYLON_NATIVE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/BabylonNative EXCLUDE_FROM_ALL)
+# Disable Unity build for UrlLib because of conflict in header between windows.h and winrt
+set_property(TARGET UrlLib PROPERTY UNITY_BUILD false)
 
 add_library(BabylonNative
     ${SHARED_SOURCES})

--- a/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
+++ b/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
@@ -47,7 +47,7 @@ function Restore-CMakeProject {
     }
     
     cd $BuildDir
-    cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -A $Arch ..\..\..\windows
+    cmake -G "Visual Studio 16 2019" -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -G "Visual Studio 16 2019" -A $Arch ..\..\..\windows 
 
     if ($? -Eq $False) {
       Write-Error "cmake failed. Make sure cmake is added to your PATH variable"

--- a/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
+++ b/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
@@ -47,7 +47,7 @@ function Restore-CMakeProject {
     }
     
     cd $BuildDir
-    cmake -G "Visual Studio 16 2019" -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -G "Visual Studio 16 2019" -A $Arch ..\..\..\windows 
+    cmake -G "Visual Studio 16 2019" -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -A $Arch ..\..\..\windows 
 
     if ($? -Eq $False) {
       Write-Error "cmake failed. Make sure cmake is added to your PATH variable"

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -131,7 +131,7 @@ const initializeSubmodulesMostRecentBabylonNative = async () => {
 
 const makeUWPProjectPlatform = async (name, arch) => {
   shelljs.mkdir('-p', `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
-  exec(`cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -DCMAKE_UNITY_BUILD=true ${cmakeBasekitBuildDefinition} -A ${arch} ./../../../react-native-windows/windows`, `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
+  exec(`cmake -G "Visual Studio 16 2019" -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -DCMAKE_UNITY_BUILD=true ${cmakeBasekitBuildDefinition} -A ${arch} ./../../../react-native-windows/windows`, `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
 };
 
 const makeUWPProjectx86 = async () => makeUWPProjectPlatform('x86', 'Win32');


### PR DESCRIPTION
- long paths support for git
- added _deps link folders and removed deprecated ones
- disable UnityBuild for UrlLib
- added glslang-default-resource-limit link library
- explicitly set CMake Windows projects output to be vs2019 